### PR TITLE
Fixes memory leak, closes #2

### DIFF
--- a/cpp/fdct2d_wrapper.cpp
+++ b/cpp/fdct2d_wrapper.cpp
@@ -74,6 +74,8 @@ vector<vector<py::array_t<cpx>>> fdct2d_forward_wrap(int nbscales, int nbangles_
         c[i].resize(cmat[i].size());
         for (size_t j = 0; j < cmat[i].size(); j++)
         {
+            // Create capsule linked to `cmat[i][j]._data` to track its lifetime
+            // https://stackoverflow.com/questions/44659924/returning-numpy-arrays-via-pybind11
             py::capsule free_when_done(
                 cmat[i][j].data(),
                 [](void *cpx_ptr)

--- a/cpp/fdct2d_wrapper.cpp
+++ b/cpp/fdct2d_wrapper.cpp
@@ -163,7 +163,10 @@ py::array_t<cpx> fdct2d_inverse_wrap(int m, int n, int nbscales, int nbangles_co
 PYBIND11_MODULE(fdct2d_wrapper, m)
 {
     m.doc() = "FDCT2D pybind11 wrapper";
-    m.def("fdct2d_param_wrap", &fdct2d_param_wrap, "Parameters for 2D FDCT");
-    m.def("fdct2d_forward_wrap", &fdct2d_forward_wrap, "2D Forward FDCT");
-    m.def("fdct2d_inverse_wrap", &fdct2d_inverse_wrap, "2D Inverse FDCT");
+    m.def("fdct2d_param_wrap", &fdct2d_param_wrap, "Parameters for 2D FDCT",
+          py::return_value_policy::take_ownership);
+    m.def("fdct2d_forward_wrap", &fdct2d_forward_wrap, "2D Forward FDCT",
+          py::return_value_policy::take_ownership);
+    m.def("fdct2d_inverse_wrap", &fdct2d_inverse_wrap, "2D Inverse FDCT",
+          py::return_value_policy::take_ownership);
 }

--- a/cpp/fdct3d_wrapper.cpp
+++ b/cpp/fdct3d_wrapper.cpp
@@ -163,7 +163,10 @@ py::array_t<cpx> fdct3d_inverse_wrap(int m, int n, int p, int nbscales, int nban
 PYBIND11_MODULE(fdct3d_wrapper, m)
 {
     m.doc() = "FDCT3D pybind11 wrapper";
-    m.def("fdct3d_param_wrap", &fdct3d_param_wrap, "Parameters for 3D FDCT");
-    m.def("fdct3d_forward_wrap", &fdct3d_forward_wrap, "3D Forward FDCT");
-    m.def("fdct3d_inverse_wrap", &fdct3d_inverse_wrap, "3D Inverse FDCT");
+    m.def("fdct3d_param_wrap", &fdct3d_param_wrap, "Parameters for 3D FDCT",
+          py::return_value_policy::take_ownership);
+    m.def("fdct3d_forward_wrap", &fdct3d_forward_wrap, "3D Forward FDCT",
+          py::return_value_policy::take_ownership);
+    m.def("fdct3d_inverse_wrap", &fdct3d_inverse_wrap, "3D Inverse FDCT",
+          py::return_value_policy::take_ownership);
 }

--- a/cpp/fdct3d_wrapper.cpp
+++ b/cpp/fdct3d_wrapper.cpp
@@ -71,6 +71,8 @@ vector<vector<py::array_t<cpx>>> fdct3d_forward_wrap(int nbscales, int nbangles_
         c[i].resize(ctns[i].size());
         for (size_t j = 0; j < ctns[i].size(); j++)
         {
+            // Create capsule linked to `ctns[i][j]._data` to track its lifetime
+            // https://stackoverflow.com/questions/44659924/returning-numpy-arrays-via-pybind11
             py::capsule free_when_done(
                 ctns[i][j].data(),
                 [](void *cpx_ptr)


### PR DESCRIPTION
Fixes memory leak reported in #2 by making sure the data created by CurveLab is deleted when the attached NumPy array is garbage-collected.

Previous memory profile (crashed):

![Linear memory profile before fix](https://imgur.com/xHgslsy.png)

After fix:

![Flat memory profile after fix](https://imgur.com/UqmIWZS.png)