### PR TITLE
Allows FDCT to be picklable so they can be used with `BlockDiag(nproc>1)`

### DIFF
--- a/curvelops/curvelops.py
+++ b/curvelops/curvelops.py
@@ -7,7 +7,7 @@ Provides a LinearOperator for the 2D and 3D curvelet transforms.
 
 from itertools import product
 from math import prod
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable, Optional, Self, Tuple, TypeAlias, Union
 
 import numpy as np
 from numpy.core.multiarray import normalize_axis_index  # type: ignore
@@ -29,6 +29,8 @@ from .fdct3d_wrapper import (  # noqa: F403
 
 # pylint: enable=no-name-in-module
 from .typing import FDCTStructLike
+
+FDCTPickle: TypeAlias = dict[str, tuple[int, ...] | int | bool]
 
 
 def _fdct_docs(dimension: int) -> str:
@@ -155,19 +157,20 @@ class FDCT(LinearOperator):
             dims=self.inpdims,
             dimsd=(*iterable_dims, self._output_len),
         )
-    def __getstate__(self: Self) -> dict[str, tuple[int, ...]|int|bool]:
+
+    def __getstate__(self: Self) -> FDCTPickle:
         state = {
             "dims": tuple(self.inpdims),
             "axes": self.axes,
             "nbscales": self.nbscales,
             "nbangles_coarse": self.nbangles_coarse,
             "allcurvelets": self.allcurvelets,
-            "dtype":self.dtype
+            "dtype": self.dtype,
         }
         return state
 
-    def __setstate__(self:Self, state: dict[str, tuple[int, ...]|int|bool])->None:
-        self.__init__(**state)
+    def __setstate__(self: Self, state: FDCTPickle) -> None:
+        self.__init__(**state)  # type: ignore
 
     def _matvec(self, x: NDArray) -> NDArray:
         fwd_out = np.zeros((self._output_len, self._ndim_iterable), dtype=self.dtype)
@@ -265,7 +268,7 @@ class FDCT(LinearOperator):
         """
         return np.concatenate([coef.ravel() for angle in x for coef in angle])
 
-import typing import Self, Any
+
 class FDCT2D(FDCT):
     __doc__ = _fdct_docs(2)
 
@@ -280,7 +283,6 @@ class FDCT2D(FDCT):
     ) -> None:
         assert len(axes) == 2, ValueError("FDCT2D must be called with exactly two axes")
         super().__init__(dims, axes, nbscales, nbangles_coarse, allcurvelets, dtype)
-    
 
 
 class FDCT3D(FDCT):

--- a/curvelops/curvelops.py
+++ b/curvelops/curvelops.py
@@ -155,6 +155,19 @@ class FDCT(LinearOperator):
             dims=self.inpdims,
             dimsd=(*iterable_dims, self._output_len),
         )
+    def __getstate__(self: Self) -> dict[str, tuple[int, ...]|int|bool]:
+        state = {
+            "dims": tuple(self.inpdims),
+            "axes": self.axes,
+            "nbscales": self.nbscales,
+            "nbangles_coarse": self.nbangles_coarse,
+            "allcurvelets": self.allcurvelets,
+            "dtype":self.dtype
+        }
+        return state
+
+    def __setstate__(self:Self, state: dict[str, tuple[int, ...]|int|bool])->None:
+        self.__init__(**state)
 
     def _matvec(self, x: NDArray) -> NDArray:
         fwd_out = np.zeros((self._output_len, self._ndim_iterable), dtype=self.dtype)
@@ -252,7 +265,7 @@ class FDCT(LinearOperator):
         """
         return np.concatenate([coef.ravel() for angle in x for coef in angle])
 
-
+import typing import Self, Any
 class FDCT2D(FDCT):
     __doc__ = _fdct_docs(2)
 
@@ -267,6 +280,7 @@ class FDCT2D(FDCT):
     ) -> None:
         assert len(axes) == 2, ValueError("FDCT2D must be called with exactly two axes")
         super().__init__(dims, axes, nbscales, nbangles_coarse, allcurvelets, dtype)
+    
 
 
 class FDCT3D(FDCT):


### PR DESCRIPTION
# Description

Allows FDCT to be picklable so they can be used with `BlockDiag(nproc>1)`

# Changes
* Implements `__getstate__` and `__setstate__` in base FDCT.

# Test script

```python
import numpy as np

from pylops import BlockDiag
from curvelops import FDCT2D

nr = 10
ns = 312
nt = 1016

nbscales = 4
nbangles_coarse = 8
allcurvelets = False

DCTOp = FDCT2D((ns, nt), nbscales=nbscales,
    nbangles_coarse=nbangles_coarse,
    allcurvelets=allcurvelets, dtype="complex64")

DCTOp1 = DCTOp.H

SopDiag = []
for i in range(nr):
    SopDiag.append(DCTOp1)
SopDiag = BlockDiag(SopDiag, nproc=2)

data = np.zeros(SopDiag.shape[1])
SopDiag @ data # This errors in the main branch
```